### PR TITLE
Fix "stateful code" checker error

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,7 +1,5 @@
 ;; shadow-cljs configuration
-{:source-paths ["src" "test"]
-
- :lein true
+{:lein true
 
  :builds {:tests {:target :node-test
                   :output-to "target/all_tests.js"

--- a/src/check/core.cljc
+++ b/src/check/core.cljc
@@ -101,7 +101,7 @@
           :expected rgt#
           :actual (symbol (:failure-message res#))}))
      {:type :error
-      :expected rgt#
+      :expected ~right
       :actual (str "Matcher " '~matcher " is not implemented")}))
 
 (defmacro defmatcher [name args & body]

--- a/test/check/core_test.cljc
+++ b/test/check/core_test.cljc
@@ -1,6 +1,6 @@
 (ns check.core-test
   (:require [clojure.string :as str]
-            [clojure.test :refer [deftest testing] :as t]
+            [clojure.test :refer [deftest testing run-tests] :as t]
             [check.core :refer [check] :as check :include-macros true]))
 
 (deftest check-wraps-matcher-combinators
@@ -39,3 +39,15 @@
 (deftest custom-matcher
   (let [obj #?(:cljs (js/Object.) :clj (Object.))]
     (check obj is-the-same? obj)))
+
+(defn stateful-obj []
+  (let [a (atom [])]
+    (fn [x]
+      (swap! a conj (inc x))
+      @a)))
+
+(deftest stateful-matchers
+  (let [add! (stateful-obj)]
+    (check (add! 10) => [11])
+    (check (add! 11) => [11 12])
+    (check (add! 12) => [11 12 13])))


### PR DESCRIPTION
When you had a code that would cause a side-effect, the default checker would sometimes (mostly always!) cause the function to run more than once - causing the side-effect twice, and probably breaking your tests